### PR TITLE
Cache dir and temp dir are not guaranteed to be on the same mount 

### DIFF
--- a/dogpile_filesystem/backend.py
+++ b/dogpile_filesystem/backend.py
@@ -6,6 +6,7 @@ Provides backends that deal with local filesystem access.
 
 """
 import collections
+import fcntl
 import hashlib
 import io
 import os
@@ -21,6 +22,8 @@ from . import registry
 from . import utils
 
 __all__ = ["RawFSBackend", "GenericFSBackend"]
+
+from .utils import LockedNamedTemporaryFile
 
 Metadata = collections.namedtuple(
     "Metadata", ["original_file_offset", "dogpile_metadata"]
@@ -150,14 +153,16 @@ class RawFSBackend(CacheBackend):
         else:
             payload, dogpile_metadata = value, None
 
+        tmpfile_cleaner = lambda: None
         original_file_offset = payload.tell()
         if self.file_movable:
             payload_file_path = payload.name
         else:
             payload.seek(0)
             try:
-                with tempfile.NamedTemporaryFile(delete=False, dir=self.temp_dir) as tmpfile:
-                    copyfileobj(payload, tmpfile, length=1024 * 1024)
+                tmpfile, tmpfile_cleaner = LockedNamedTemporaryFile(delete=False, dir=self.temp_dir)
+                fcntl.flock(tmpfile.fileno(), fcntl.LOCK_EX)  # Need the lock until after os.rename below
+                copyfileobj(payload, tmpfile, length=1024 * 1024)
             finally:
                 payload.seek(original_file_offset, 0)
             payload_file_path = tmpfile.name
@@ -165,14 +170,18 @@ class RawFSBackend(CacheBackend):
         metadata = Metadata(
             dogpile_metadata=dogpile_metadata, original_file_offset=original_file_offset
         )
-        with tempfile.NamedTemporaryFile(delete=False, dir=self.temp_dir) as metadata_file:
-            pickle.dump(metadata, metadata_file, pickle.HIGHEST_PROTOCOL)
+        metadata_file, metadata_file_cleaner = LockedNamedTemporaryFile(delete=False, dir=self.temp_dir)
+        fcntl.flock(metadata_file.fileno(), fcntl.LOCK_EX)  # Need the lock until after os.rename below
+        pickle.dump(metadata, metadata_file, pickle.HIGHEST_PROTOCOL)
 
         with self._get_rw_lock(key):
             os.rename(metadata_file.name, self._file_path_metadata(key))
             os.rename(payload_file_path, self._file_path_payload(key))
             os.utime(self._file_path_metadata(key), (now_timestamp, now_timestamp))
             os.utime(self._file_path_payload(key), (now_timestamp, now_timestamp))
+
+        metadata_file_cleaner()
+        tmpfile_cleaner()
 
     def set_multi(self, mapping):
         for key, value in mapping.items():
@@ -253,6 +262,17 @@ class RawFSBackend(CacheBackend):
         ):
             key = keys_by_newest.pop()
             self.attempt_delete_key(key)
+
+        # Cleanup abandoned tmpfiles
+        for file in os.listdir(self.temp_dir):
+            try:
+                with open(file, 'rb') as fp:
+                    fcntl.flock(fp.fileno(), fcntl.LOCK_EX|fcntl.LOCK_NB)
+                os.remove(file)
+            except OSError as e:
+                pass  # Active tempfile
+            finally:
+                fcntl.flock(fp.fileno(), fcntl.LOCK_EX|fcntl.LOCK_NB)
 
 
 class GenericFSBackend(RawFSBackend):

--- a/dogpile_filesystem/backend.py
+++ b/dogpile_filesystem/backend.py
@@ -80,8 +80,8 @@ class RawFSBackend(CacheBackend):
         self.values_dir = os.path.join(self.base_dir, "values")
         utils.ensure_dir(self.values_dir)
 
-        self.tmp_dir = os.path.join(self.base_dir, "tmp")
-        utils.ensure_dir(self.tmp_dir)
+        self.temp_dir = os.path.join(self.base_dir, "tmp")
+        utils.ensure_dir(self.temp_dir)
 
         self.dogpile_lock_path = os.path.join(self.base_dir, "dogpile.lock")
         self.rw_lock_path = os.path.join(self.base_dir, "rw.lock")
@@ -156,7 +156,7 @@ class RawFSBackend(CacheBackend):
         else:
             payload.seek(0)
             try:
-                with tempfile.NamedTemporaryFile(delete=False, dir=self.tmp_dir) as tmpfile:
+                with tempfile.NamedTemporaryFile(delete=False, dir=self.temp_dir) as tmpfile:
                     copyfileobj(payload, tmpfile, length=1024 * 1024)
             finally:
                 payload.seek(original_file_offset, 0)
@@ -165,7 +165,7 @@ class RawFSBackend(CacheBackend):
         metadata = Metadata(
             dogpile_metadata=dogpile_metadata, original_file_offset=original_file_offset
         )
-        with tempfile.NamedTemporaryFile(delete=False, dir=self.tmp_dir) as metadata_file:
+        with tempfile.NamedTemporaryFile(delete=False, dir=self.temp_dir) as metadata_file:
             pickle.dump(metadata, metadata_file, pickle.HIGHEST_PROTOCOL)
 
         with self._get_rw_lock(key):
@@ -295,7 +295,7 @@ class GenericFSBackend(RawFSBackend):
         super(GenericFSBackend, self).__init__(arguments)
 
     def set(self, key, value):
-        with tempfile.NamedTemporaryFile(delete=False, dir=self.tmp_dir) as value_file:
+        with tempfile.NamedTemporaryFile(delete=False, dir=self.temp_dir) as value_file:
             pickle.dump(value, value_file, pickle.HIGHEST_PROTOCOL)
             value_file.seek(0)
             value_file.flush()

--- a/dogpile_filesystem/backend.py
+++ b/dogpile_filesystem/backend.py
@@ -75,6 +75,8 @@ class RawFSBackend(CacheBackend):
 
     @staticmethod
     def key_mangler(key):
+        if isinstance(key, bytes):
+            return key
         return hashlib.sha256(key.encode("utf-8")).hexdigest()
 
     def __init__(self, arguments):

--- a/dogpile_filesystem/backend.py
+++ b/dogpile_filesystem/backend.py
@@ -6,17 +6,14 @@ Provides backends that deal with local filesystem access.
 
 """
 import collections
-import fcntl
 import hashlib
 import io
 import os
 import pickle
-import tempfile
 import time
 
 from shutil import copyfileobj
 
-import errno
 from dogpile.cache.api import CacheBackend, NO_VALUE, CachedValue
 
 from . import registry
@@ -76,8 +73,10 @@ class RawFSBackend(CacheBackend):
     @staticmethod
     def key_mangler(key):
         if isinstance(key, bytes):
-            return key
-        return hashlib.sha256(key.encode("utf-8")).hexdigest()
+            key_bytes = key
+        else:
+            key_bytes = key.encode("utf-8")
+        return hashlib.sha256(key_bytes).hexdigest()
 
     def __init__(self, arguments):
         self.base_dir = os.path.abspath(os.path.normpath(arguments["base_dir"]))

--- a/dogpile_filesystem/backend.py
+++ b/dogpile_filesystem/backend.py
@@ -80,6 +80,9 @@ class RawFSBackend(CacheBackend):
         self.values_dir = os.path.join(self.base_dir, "values")
         utils.ensure_dir(self.values_dir)
 
+        self.tmp_dir = os.path.join(self.base_dir, "tmp")
+        utils.ensure_dir(self.tmp_dir)
+
         self.dogpile_lock_path = os.path.join(self.base_dir, "dogpile.lock")
         self.rw_lock_path = os.path.join(self.base_dir, "rw.lock")
 
@@ -153,7 +156,7 @@ class RawFSBackend(CacheBackend):
         else:
             payload.seek(0)
             try:
-                with tempfile.NamedTemporaryFile(delete=False) as tmpfile:
+                with tempfile.NamedTemporaryFile(delete=False, dir=self.tmp_dir) as tmpfile:
                     copyfileobj(payload, tmpfile, length=1024 * 1024)
             finally:
                 payload.seek(original_file_offset, 0)
@@ -162,7 +165,7 @@ class RawFSBackend(CacheBackend):
         metadata = Metadata(
             dogpile_metadata=dogpile_metadata, original_file_offset=original_file_offset
         )
-        with tempfile.NamedTemporaryFile(delete=False) as metadata_file:
+        with tempfile.NamedTemporaryFile(delete=False, dir=self.tmp_dir) as metadata_file:
             pickle.dump(metadata, metadata_file, pickle.HIGHEST_PROTOCOL)
 
         with self._get_rw_lock(key):
@@ -292,7 +295,7 @@ class GenericFSBackend(RawFSBackend):
         super(GenericFSBackend, self).__init__(arguments)
 
     def set(self, key, value):
-        with tempfile.NamedTemporaryFile(delete=False) as value_file:
+        with tempfile.NamedTemporaryFile(delete=False, dir=self.tmp_dir) as value_file:
             pickle.dump(value, value_file, pickle.HIGHEST_PROTOCOL)
             value_file.seek(0)
             value_file.flush()


### PR DESCRIPTION
The problem is when for example you have a container and have the cache directory bind mounted thus being on a different file system than the temp directory of the container. This makes the os.rename fail. The proposed fix in this merge request just creates the temp directory inside the cache directory next to the values directory. This should not use any additional resources because the tempfile would eventually get in this directory anyway. The only problem I see here is that I don't know a simple way to create a test for this case.